### PR TITLE
use `bro_dist` instead of `bro` in get-bro-env since bro is undefined as of fdd1f55

### DIFF
--- a/plugin-support/skeleton/tests/Scripts/get-bro-env
+++ b/plugin-support/skeleton/tests/Scripts/get-bro-env
@@ -7,11 +7,11 @@ bro_dist=`cat ${base}/../../build/CMakeCache.txt | grep BRO_DIST | cut -d = -f 2
 
 if [ -n "${bro_dist}" ]; then
     if [ "$1" = "bropath" ]; then
-        ${bro}/build/bro-path-dev
+        ${bro_dist}/build/bro-path-dev
     elif [ "$1" = "bro_plugin_path" ]; then
         ( cd ${base}/../.. && pwd )
     elif [ "$1" = "path" ]; then
-        echo ${bro}/build/src:${bro}/aux/btest:${base}/:${bro}/aux/bro-cut:$PATH
+        echo ${bro_dist}/build/src:${bro_dist}/aux/btest:${base}/:${bro_dist}/aux/bro-cut:$PATH
     else
         echo "usage: `basename $0` <var>" >&2
         exit 1


### PR DESCRIPTION
In fdd1f55 @rsmmr changed the get-bro-env script to use the `bro_dist` variable instead of the `bro` variable but did not update everything. This pull request fixes this.

Thanks a bunch!