### PR TITLE
Remove version number from the show-plugin.bro btest, in prep for Bro 2.7

### DIFF
--- a/plugin-support/skeleton/tests/%NAME_LOWER@show-plugin.bro
+++ b/plugin-support/skeleton/tests/%NAME_LOWER@show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN @PLUGIN_NAMESPACE@::@PLUGIN_NAME@ >output
+# @TEST-EXEC: bro -NN @PLUGIN_NAMESPACE@::@PLUGIN_NAME@ |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Prior to Bro 2.7, plugin version numbers are generated as "major.minor".  With Bro 2.7, plugin version numbers are created as "major.minor.patch".  This breaks btests where the Baseline was generated with a pre-2.7 version of Bro. 

This fix will solve the issue for future packages that are created before the 2.7 release and I've submitted pull requests for several existing packages to update those as well.
